### PR TITLE
Bump version to 3.0.0-SNAPSHOT for XP 8

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            2.x
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds `releaseBranch:` block listing `master` and `2.x` so `enonic/release-tools/build-and-publish` recognizes both as release branches.
- Version on `master` is already `3.0.0-SNAPSHOT` (set during the XP 8 upgrade), so no `gradle.properties` change is needed.
- Maintenance branch `2.x` was created from the post-release SNAPSHOT commit `8857b98`.

## Test plan
- [ ] CI green on this PR
- [ ] After merge, `master` build classified as a release branch by build-and-publish
- [ ] Companion PR on `2.x` adds the same workflow block so `2.x` pushes are also classified as release-branch builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)