### PR TITLE
Add release-branch CI config for 2.x

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ${{ secrets.ARTIFACTORY_USERNAME }}
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            2.x
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds the `releaseBranch:` block (listing `master` and `2.x`) to the workflow on the `2.x` maintenance branch.
- This is required so `enonic/release-tools/build-and-publish` reads `releaseBranch:` from `2.x`'s own workflow file and classifies pushes to `2.x` as release-branch builds.
- No version bump or other Step-2 changes are copied here — those are master-only.

## Test plan
- [ ] CI green on this PR
- [ ] After merge, a CI run on `2.x` is classified as a release-branch build
- [ ] `gradle.properties` on `2.x` stays at `version=2.0.2-SNAPSHOT`

🤖 Generated with [Claude Code](https://claude.com/claude-code)